### PR TITLE
Separate layout properties into per-container classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint-all:
 	flake8 src/invent tests/*
 
 serve: clean tidy zip
-	python utils/serve.py 8000
+	python utils/serve.py
 
 test:
 	python -m webbrowser http://localhost:8000/index.html

--- a/examples/calculator/main.py
+++ b/examples/calculator/main.py
@@ -105,7 +105,7 @@ invent.ui.App(
                     columns=4,
                     content=[
                         invent.ui.TextInput(
-                            column_span=4,
+                            layout=dict(column_span=4),
                             value=invent.ui.from_datastore("numbers"),
                         ),
                         invent.ui.Button(
@@ -163,7 +163,7 @@ invent.ui.App(
                             label="+", purpose="SUCCESS", channel="calculator"
                         ),
                         invent.ui.Button(
-                            column_span=2,
+                            layout=dict(column_span=2),
                             label="0",
                             purpose="DEFAULT",
                             channel="calculator",

--- a/examples/catfacts/main.py
+++ b/examples/catfacts/main.py
@@ -61,7 +61,7 @@ app = App(
                         Image(
                             image=invent.media.images.puff.svg,
                             visible=from_datastore("working"),
-                            align_self="center",
+                            layout=dict(align_self="center"),
                         ),
                         Button(
                             name="cat_fact_button",
@@ -77,7 +77,7 @@ app = App(
                             text=from_datastore(
                                 "cat_fact", with_function=handle_cat_fact
                             ),
-                            align_self="center",
+                            layout=dict(align_self="center"),
                         ),
                     ]
                 ),

--- a/examples/farmyard/main.py
+++ b/examples/farmyard/main.py
@@ -69,10 +69,10 @@ app = App(
                         Image(
                             image=invent.media.images.goose.png,
                             channel="honk",
-                            align_self="center",
+                            layout=dict(align_self="center"),
                         ),
                         Row(
-                            align_self="center",
+                            layout=dict(align_self="center"),
                             content=[
                                 Button(
                                     name="button honk",
@@ -91,13 +91,13 @@ app = App(
                                 TextBox(
                                     name="number_of_honks",
                                     text=from_datastore("number_of_honks"),
-                                    align_self="center",
+                                    layout=dict(align_self="center"),
                                 ),
                                 Slider(
                                     value=from_datastore("number_of_honks"),
                                     name="Honk Slider",
                                     step=1,
-                                    flex=1,
+                                    layout=dict(flex=1),
                                 ),
                             ]
                         ),
@@ -125,10 +125,10 @@ app = App(
                         Image(
                             image=invent.media.images.pig.png,
                             channel="oink",
-                            align_self="center",
+                            layout=dict(align_self="center"),
                         ),
                         Row(
-                            align_self="center",
+                            layout=dict(align_self="center"),
                             content=[
                                 Button(
                                     name="button oink",
@@ -143,7 +143,7 @@ app = App(
                                 TextBox(
                                     name="number_of_oinks",
                                     text=from_datastore("number_of_oinks"),
-                                    align_self="center",
+                                    layout=dict(align_self="center"),
                                 ),
                             ],
                         ),
@@ -180,13 +180,13 @@ app.content.append(
                         name="to_lucy",
                         label="Visit Lucy",
                         channel="navigate",
-                        flex=1,
+                        layout=dict(flex=1),
                     ),
                     Button(
                         name="to_percy",
                         label="Visit Percy",
                         channel="navigate",
-                        flex=1,
+                        layout=dict(flex=1),
                     ),
                 ]
             ),

--- a/src/invent/compatability.py
+++ b/src/invent/compatability.py
@@ -30,6 +30,11 @@ def iscoroutinefunction(obj):
     return inspect.iscoroutinefunction(obj)
 
 
+def capitalize(s):
+    """Cross-interpreter implementation of str.capitalize."""
+    return s[0].upper() + s[1:].lower()
+
+
 async def sleep_ms(ms):
     """Asynchronous sleep for 'ms' milliseconds."""
 

--- a/src/invent/ui/containers/box.py
+++ b/src/invent/ui/containers/box.py
@@ -19,6 +19,7 @@ def flex_property(direction):
         "May be blank to take no extra space, "
         "'auto' to take an equal portion of any free space, "
         "or an integer to take the given proportion of the total space.",
+        default_value="",
         map_to_style="flex",
     )
 

--- a/src/invent/ui/containers/box.py
+++ b/src/invent/ui/containers/box.py
@@ -1,11 +1,26 @@
-from ..core import Container, ChoiceProperty
+from ...compatability import capitalize
+from ..core import Container, ChoiceProperty, TextProperty
 from ..core.component import _TSHIRT_SIZES, ALIGNMENTS
 
-justify_content_kwargs = dict(
-    choices=ALIGNMENTS,
-    default_value="start",
-    map_to_style="justify-content"
-)
+
+def justify_content_property(direction):
+    return ChoiceProperty(
+        f"{capitalize(direction)} alignment of children.",
+        choices=ALIGNMENTS,
+        default_value="start",
+        map_to_style="justify-content"
+    )
+
+
+def flex_property(direction):
+    # TODO: validate input
+    return TextProperty(
+        f"How much {direction} space to consume. " +
+        "May be blank to take no extra space, "
+        "'auto' to take an equal portion of any free space, "
+        "or an integer to take the given proportion of the total space.",
+        map_to_style="flex",
+    )
 
 
 class Box(Container):

--- a/src/invent/ui/containers/column.py
+++ b/src/invent/ui/containers/column.py
@@ -1,5 +1,5 @@
-from ..core import ChoiceProperty
-from .box import Box, justify_content_kwargs
+from ..core.component import align_self_property, BaseLayout
+from .box import Box, flex_property, justify_content_property
 
 
 class Column(Box):
@@ -13,7 +13,8 @@ class Column(Box):
 
     flex_direction = "column"
 
-    justify_content = ChoiceProperty(
-        "Vertical alignment of children",
-        **justify_content_kwargs,
-    )
+    justify_content = justify_content_property("vertical")
+
+    class Layout(BaseLayout):
+        align_self = align_self_property("horizontal")
+        flex = flex_property("vertical")

--- a/src/invent/ui/containers/column.py
+++ b/src/invent/ui/containers/column.py
@@ -1,5 +1,10 @@
-from ..core.component import align_self_property, BaseLayout
+from ..core.component import align_self_property, Layout
 from .box import Box, flex_property, justify_content_property
+
+
+class ColumnLayout(Layout):
+    align_self = align_self_property("horizontal")
+    flex = flex_property("vertical")
 
 
 class Column(Box):
@@ -11,10 +16,7 @@ class Column(Box):
     def icon(cls):
         return '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 256 256"><path fill="currentColor" d="M104 32H64a16 16 0 0 0-16 16v160a16 16 0 0 0 16 16h40a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16m0 176H64V48h40Zm88-176h-40a16 16 0 0 0-16 16v160a16 16 0 0 0 16 16h40a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16m0 176h-40V48h40Z"/></svg>'  # noqa
 
+    layout_class = ColumnLayout
     flex_direction = "column"
 
     justify_content = justify_content_property("vertical")
-
-    class Layout(BaseLayout):
-        align_self = align_self_property("horizontal")
-        flex = flex_property("vertical")

--- a/src/invent/ui/containers/grid.py
+++ b/src/invent/ui/containers/grid.py
@@ -1,5 +1,10 @@
 from ..core import Container, ChoiceProperty, IntegerProperty
-from ..core.component import _TSHIRT_SIZES
+from ..core.component import (
+    _TSHIRT_SIZES,
+    ALIGNMENTS_STRETCH,
+    BaseLayout,
+    align_self_property,
+)
 
 
 class Grid(Container):
@@ -19,6 +24,24 @@ class Grid(Container):
     )
 
     columns = IntegerProperty("Number of columns.", 4)
+
+    class Layout(BaseLayout):
+        align_self = align_self_property("vertical")
+        justify_self = ChoiceProperty(
+            "Horizontal alignment.",
+            choices=ALIGNMENTS_STRETCH,
+            default_value="stretch",
+            map_to_style="justify-self",
+        )
+
+        column_span = IntegerProperty("Number of columns to fill.", 1)
+        row_span = IntegerProperty("Number of rows to fill.", 1)
+
+        def on_column_span_changed(self):
+            self.element.style.gridColumn = f"span {self.column_span}"
+
+        def on_row_span_changed(self):
+            self.element.style.gridRow = f"span {self.row_span}"
 
     @classmethod
     def icon(cls):
@@ -40,12 +63,3 @@ class Grid(Container):
         element = super().render()
         element.style.display = "grid"
         return element
-
-    def update_child(self, child, index):
-        grid_row_span = child.row_span
-        if grid_row_span:
-            child.element.style.gridRow = "span " + str(grid_row_span)
-
-        grid_column_span = child.column_span
-        if grid_column_span:
-            child.element.style.gridColumn = "span " + str(grid_column_span)

--- a/src/invent/ui/containers/grid.py
+++ b/src/invent/ui/containers/grid.py
@@ -2,15 +2,36 @@ from ..core import Container, ChoiceProperty, IntegerProperty
 from ..core.component import (
     _TSHIRT_SIZES,
     ALIGNMENTS_STRETCH,
-    BaseLayout,
+    Layout,
     align_self_property,
 )
+
+
+class GridLayout(Layout):
+    align_self = align_self_property("vertical")
+    justify_self = ChoiceProperty(
+        "Horizontal alignment.",
+        choices=ALIGNMENTS_STRETCH,
+        default_value="stretch",
+        map_to_style="justify-self",
+    )
+
+    column_span = IntegerProperty("Number of columns to fill.", 1)
+    row_span = IntegerProperty("Number of rows to fill.", 1)
+
+    def on_column_span_changed(self):
+        self.element.style.gridColumn = f"span {self.column_span}"
+
+    def on_row_span_changed(self):
+        self.element.style.gridRow = f"span {self.row_span}"
 
 
 class Grid(Container):
     """
     A grid.
     """
+
+    layout_class = GridLayout
 
     column_gap = ChoiceProperty(
         "The gap between columns in the grid.",
@@ -24,24 +45,6 @@ class Grid(Container):
     )
 
     columns = IntegerProperty("Number of columns.", 4)
-
-    class Layout(BaseLayout):
-        align_self = align_self_property("vertical")
-        justify_self = ChoiceProperty(
-            "Horizontal alignment.",
-            choices=ALIGNMENTS_STRETCH,
-            default_value="stretch",
-            map_to_style="justify-self",
-        )
-
-        column_span = IntegerProperty("Number of columns to fill.", 1)
-        row_span = IntegerProperty("Number of rows to fill.", 1)
-
-        def on_column_span_changed(self):
-            self.element.style.gridColumn = f"span {self.column_span}"
-
-        def on_row_span_changed(self):
-            self.element.style.gridRow = f"span {self.row_span}"
 
     @classmethod
     def icon(cls):

--- a/src/invent/ui/containers/row.py
+++ b/src/invent/ui/containers/row.py
@@ -1,5 +1,10 @@
-from ..core.component import BaseLayout, align_self_property
+from ..core.component import Layout, align_self_property
 from .box import Box, flex_property, justify_content_property
+
+
+class RowLayout(Layout):
+    align_self = align_self_property("vertical")
+    flex = flex_property("horizontal")
 
 
 class Row(Box):
@@ -11,10 +16,7 @@ class Row(Box):
     def icon(cls):
         return '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 256 256"><path fill="currentColor" d="M208 136H48a16 16 0 0 0-16 16v40a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16v-40a16 16 0 0 0-16-16m0 56H48v-40h160zm0-144H48a16 16 0 0 0-16 16v40a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16m0 56H48V64h160z"/></svg>'  # noqa
 
+    layout_class = RowLayout
     flex_direction = "row"
 
     justify_content = justify_content_property("horizontal")
-
-    class Layout(BaseLayout):
-        align_self = align_self_property("vertical")
-        flex = flex_property("horizontal")

--- a/src/invent/ui/containers/row.py
+++ b/src/invent/ui/containers/row.py
@@ -1,5 +1,5 @@
-from ..core import ChoiceProperty
-from .box import Box, justify_content_kwargs
+from ..core.component import BaseLayout, align_self_property
+from .box import Box, flex_property, justify_content_property
 
 
 class Row(Box):
@@ -13,7 +13,8 @@ class Row(Box):
 
     flex_direction = "row"
 
-    justify_content = ChoiceProperty(
-        "Horizontal alignment of children",
-        **justify_content_kwargs,
-    )
+    justify_content = justify_content_property("horizontal")
+
+    class Layout(BaseLayout):
+        align_self = align_self_property("vertical")
+        flex = flex_property("horizontal")

--- a/src/invent/ui/core/__init__.py
+++ b/src/invent/ui/core/__init__.py
@@ -2,6 +2,7 @@ from .component import (
     _DEFAULT_ICON,
     Component,
     Container,
+    Layout,
     MessageBlueprint,
     Widget,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "FloatProperty",
     "IntegerProperty",
     "ListProperty",
+    "Layout",
     "NumericProperty",
     "Property",
     "TextProperty",

--- a/src/invent/ui/core/component.py
+++ b/src/invent/ui/core/component.py
@@ -196,9 +196,9 @@ class Component(Model):
                     # all properties.
                     self._layout = self.parent.Layout(
                         self,
-                        {
+                        **{
                             key: getattr(layout, key)
-                            for key, prop in layout.properties()
+                            for key, prop in layout.properties().items()
                         }
                     )
                 else:

--- a/src/invent/ui/core/component.py
+++ b/src/invent/ui/core/component.py
@@ -360,14 +360,6 @@ class Component(Model):
             },
         }
 
-    def get_from_datastore(self, property_name):
-        """
-        Return the "from_datastore" instance for a property or None if it is a
-        simple/literal property.
-        """
-
-        return getattr(self, f"_{property_name}_from_datastore", None)
-
     def update_attribute(self, attribute_name, attribute_value):
         """
         Convenience method to update an HTML attribute on self.element. If

--- a/src/invent/ui/core/component.py
+++ b/src/invent/ui/core/component.py
@@ -27,7 +27,6 @@ from .model import Model
 from .property import (
     BooleanProperty,
     ChoiceProperty,
-    IntegerProperty,
     ListProperty,
     TextProperty,
 )
@@ -475,18 +474,6 @@ class Container(Component):
         default_value=None,
     )
 
-    column_width = IntegerProperty(
-        "The default width of the container.",
-        default_value=100,
-        maximum=100,
-        minimum=0,
-    )
-    height = IntegerProperty(
-        "The default height of the container.",
-        default_value=100,
-        maximum=100,
-        minimum=0,
-    )
     background_color = TextProperty("The color of the container's background.")
     border_color = TextProperty("The color of the container's border.")
     border_width = ChoiceProperty(
@@ -518,12 +505,6 @@ class Container(Component):
         for child in self.content:
             self.element.appendChild(child.element)
         self.update_children()
-
-    def on_height_changed(self):
-        self.element.style.height = f"{self.height}%"
-
-    def on_width_changed(self):
-        self.element.style.width = f"{self.width}%"
 
     def on_background_color_changed(self):
         if self.background_color:

--- a/src/invent/ui/core/component.py
+++ b/src/invent/ui/core/component.py
@@ -328,19 +328,17 @@ class Component(Model):
         Return a dict representation of the state of this instance.
         """
         properties = super().as_dict()
-        properties["layout"] = (
+        layout_dict = (
             self.layout
             if isinstance(self.layout, dict)
             else self.layout.as_dict()
         )
+        if layout_dict:
+            properties["layout"] = layout_dict
 
         # If the component is a Container, we format its content recursively.
         if isinstance(self, Container):
-            from_datastore = self.get_from_datastore("content")
-            if from_datastore:
-                properties["content"] = repr(from_datastore)
-
-            else:
+            if not self.get_from_datastore("content"):
                 properties["content"] = [
                     item.as_dict() for item in self.content
                 ]

--- a/src/invent/ui/core/model.py
+++ b/src/invent/ui/core/model.py
@@ -49,4 +49,6 @@ class Model:
         Set the "from_datastore" instance for a property. Pass None to make it
         an unbound property.
         """
-        self.properties()[property_name].set_from_datastore(*args, **kwargs)
+        self.properties()[property_name].set_from_datastore(
+            self, *args, **kwargs
+        )

--- a/src/invent/ui/core/model.py
+++ b/src/invent/ui/core/model.py
@@ -1,0 +1,32 @@
+from ...compatability import getmembers_static
+from .property import Property
+
+
+class Model:
+    """
+    Base for a class which contains Properties.
+    """
+
+    def __init__(self, **kwargs):
+        self.update(**kwargs)
+
+        # Set default values.
+        for property_name, property_obj in type(self).properties().items():
+            if property_name not in kwargs:
+                if property_obj.default_value is not None:
+                    setattr(self, property_name, property_obj.default_value)
+
+    @classmethod
+    def properties(cls):
+        return {
+            name: value
+            for name, value in getmembers_static(cls)
+            if isinstance(value, Property)
+        }
+
+    def update(self, **kwargs):
+        for k, v in kwargs.items():
+            if hasattr(self, k):
+                setattr(self, k, v)
+            else:
+                raise AttributeError(k)

--- a/src/invent/ui/core/model.py
+++ b/src/invent/ui/core/model.py
@@ -8,6 +8,12 @@ class Model:
     """
 
     def __init__(self, **kwargs):
+        # MicroPython incorrectly calls __set_name__ with the Model instance,
+        # not the class. And it doesn't call it on Layout classes at all, maybe
+        # because they're nested.
+        for key, prop in self.properties().items():
+            prop.__set_name__(type(self), key)
+
         self.update(**kwargs)
 
         # Set default values.

--- a/src/invent/ui/core/model.py
+++ b/src/invent/ui/core/model.py
@@ -36,3 +36,17 @@ class Model:
                 setattr(self, k, v)
             else:
                 raise AttributeError(k)
+
+    def get_from_datastore(self, property_name):
+        """
+        Return the "from_datastore" instance for a property, or None if it is
+        an unbound property.
+        """
+        return self.properties()[property_name].get_from_datastore(self)
+
+    def set_from_datastore(self, property_name, *args, **kwargs):
+        """
+        Set the "from_datastore" instance for a property. Pass None to make it
+        an unbound property.
+        """
+        self.properties()[property_name].set_from_datastore(*args, **kwargs)

--- a/src/invent/ui/core/property.py
+++ b/src/invent/ui/core/property.py
@@ -153,17 +153,13 @@ class Property:
         old_value = self.get_from_datastore(obj)
         if old_value:
             invent.unsubscribe(
-                getattr(obj, reactor_prop),
-                to_channel="store-data",
-                when_subject=old_value.key,
+                getattr(obj, reactor_prop), "store-data", old_value.key
             )
             delattr(obj, reactor_prop)
 
         setattr(obj, self.from_datastore_name, value)
         if value:
-            invent.subscribe(
-                reactor, to_channel="store-data", when_subject=value.key
-            )
+            invent.subscribe(reactor, "store-data", value.key)
             setattr(obj, reactor_prop, reactor)
 
     def _react_on_change(self, obj, property_name):

--- a/src/invent/ui/core/property.py
+++ b/src/invent/ui/core/property.py
@@ -31,7 +31,7 @@ class from_datastore:  # NOQA
         Create the expression for a property that gets its value from the
         datastore.
         """
-        expression = f'from_datastore("{self.key}"'
+        expression = f"from_datastore({self.key!r}"
         if self.with_function:
             expression += f", with_function={self.with_function.__name__}"
         expression += ")"

--- a/src/invent/ui/export.py
+++ b/src/invent/ui/export.py
@@ -220,7 +220,7 @@ def _pretty_repr_component(component, lines, indent=""):
     _pretty_repr_component_properties(component, lines, indent + "    ")
 
     # The component's layout.
-    _pretty_repr_component_layout(component, lines, indent + "    ")
+    _pretty_repr_component_layout(component.layout, lines, indent + "    ")
 
     # If the component is a Container, its "content" property.
     if isinstance(component, Container):
@@ -231,13 +231,11 @@ def _pretty_repr_component(component, lines, indent=""):
     # The last line of the component's constructor e.g.")" :).
     lines.append(f"{indent}),")
 
-    return lines
-
 
 def _pretty_repr_component_properties(component, lines, indent):
     """Generate a pretty repr of a Component's properties."""
 
-    for property_name, property_obj in type(component).properties().items():
+    for property_name, property_obj in sorted(component.properties().items()):
         # If the component is a Container, we deal with its content separately
         # (for the recursive case). A Widget may well define its own custom
         # "content" property though, so we handle that just like any other
@@ -255,13 +253,13 @@ def _pretty_repr_component_properties(component, lines, indent):
         lines.append(f"{indent}{property_name}={repr(property_value)},")
 
 
-def _pretty_repr_component_layout(component, lines, indent):
-    layout_dict = (
-        component.layout
-        if isinstance(component.layout, dict)
-        else component.layout.as_dict()
-    )
-    lines.append(f"{indent}layout={layout_dict},")
+def _pretty_repr_component_layout(layout, lines, indent):
+    layout_dict = layout if isinstance(layout, dict) else layout.as_dict()
+    if layout_dict:
+        dict_args = [
+            f"{key}={value!r}" for key, value in sorted(layout_dict.items())
+        ]
+        lines.append(f"{indent}layout=dict({', '.join(dict_args)}),")
 
 
 def _pretty_repr_container_content_property(component, lines, indent):

--- a/src/invent/ui/export.py
+++ b/src/invent/ui/export.py
@@ -219,6 +219,9 @@ def _pretty_repr_component(component, lines, indent=""):
     # The component's properties.
     _pretty_repr_component_properties(component, lines, indent + "    ")
 
+    # The component's layout.
+    _pretty_repr_component_layout(component, lines, indent + "    ")
+
     # If the component is a Container, its "content" property.
     if isinstance(component, Container):
         _pretty_repr_container_content_property(
@@ -250,6 +253,15 @@ def _pretty_repr_component_properties(component, lines, indent):
         )
 
         lines.append(f"{indent}{property_name}={repr(property_value)},")
+
+
+def _pretty_repr_component_layout(component, lines, indent):
+    layout_dict = (
+        component.layout
+        if isinstance(component.layout, dict)
+        else component.layout.as_dict()
+    )
+    lines.append(f"{indent}layout={layout_dict},")
 
 
 def _pretty_repr_container_content_property(component, lines, indent):

--- a/src/tools/builder/public/python/builder.py
+++ b/src/tools/builder/public/python/builder.py
@@ -6,6 +6,7 @@ import json
 from pyscript import document
 from pyscript.ffi import create_proxy
 
+from invent import datastore
 from invent.ui import (
     App, AVAILABLE_COMPONENTS, Column, Container, create_component, export, Grid, Page,
     Row, Widget, from_datastore
@@ -241,10 +242,10 @@ class Builder:
             else:
                 target = component
 
-            if hasattr(component, f"_{name}_from_datastore"):
+            binding = target.get_from_datastore(name)
+            if binding:
                 value["is_from_datastore"] = True
-                datastore_value = getattr(target, f"_{name}_from_datastore")
-                value["value"] = datastore_value.key
+                value["value"] = binding.key
             else:
                 value["value"] = getattr(target, name)
             
@@ -267,6 +268,7 @@ class Builder:
         if is_from_datastore:
             setattr(target, property_name, from_datastore(value))
         else:
+            target.set_from_datastore(property_name, None)
             setattr(target, property_name, value)
 
     def show_page(self, page_id):
@@ -274,7 +276,12 @@ class Builder:
         if result:
             result.show()
             return result.element
-        
+
+    # Datastore ###################################################################
+
+    def update_datastore(self, key, value):
+        datastore[key] = value
+
     # Channels ####################################################################
         
     def get_channels(self):

--- a/src/tools/builder/src/data/models/widget-property-model.ts
+++ b/src/tools/builder/src/data/models/widget-property-model.ts
@@ -8,6 +8,7 @@ export interface WidgetPropertyModel {
     max_length?: number;
     choices: Array<string>;
     is_from_datastore: boolean;
+    is_layout: boolean;
     id: string;
     name: string;
 }

--- a/src/tools/builder/src/utilities/builder-utilities.ts
+++ b/src/tools/builder/src/utilities/builder-utilities.ts
@@ -53,6 +53,12 @@ export class BuilderUtilities {
 		this.builder().set_component_property(componentId, key, value, is_layout, isFromDatastore);
 	}
 
+	// Datastore ///////////////////////////////////////////////////////////////////////
+
+	public static updateDatastore(key: string, value: string) {
+		this.builder().update_datastore(key, value);
+	}
+
 	// Channels ////////////////////////////////////////////////////////////////////////
 
 	public static getChannels(): Array<string> {

--- a/src/tools/builder/src/utilities/builder-utilities.ts
+++ b/src/tools/builder/src/utilities/builder-utilities.ts
@@ -49,8 +49,8 @@ export class BuilderUtilities {
 		return JSON.parse(this.builder().get_component_properties(componentId));
 	}
 
-	public static setComponentProperty(componentId: string, key: string, value: string, isFromDatastore?: boolean) {
-		this.builder().set_component_property(componentId, key, value, isFromDatastore);
+	public static setComponentProperty(componentId: string, key: string, value: string, is_layout: boolean, isFromDatastore?: boolean) {
+		this.builder().set_component_property(componentId, key, value, is_layout, isFromDatastore);
 	}
 
 	// Channels ////////////////////////////////////////////////////////////////////////

--- a/src/tools/builder/src/views/builder/builder-model.ts
+++ b/src/tools/builder/src/views/builder/builder-model.ts
@@ -315,6 +315,9 @@ export class BuilderModel extends ViewModelBase {
 			options: {
 				onAddValue: (isValid: boolean, datastoreValue: DatastoreValueModel): void => {
 					if (isValid){
+						BuilderUtilities.updateDatastore(
+							datastoreValue.key, datastoreValue.default_value
+						);
 						this.state.datastore[datastoreValue.key] = datastoreValue;
 						ModalUtilities.closeModal();
 					}

--- a/src/tools/builder/src/views/builder/builder-model.ts
+++ b/src/tools/builder/src/views/builder/builder-model.ts
@@ -75,6 +75,7 @@ export class BuilderModel extends ViewModelBase {
 				"blocks": {}
 			}
 		}
+		
 		BuilderUtilities.getAppFromDict(data.app);
 
 		// TODO: Not sure we need to do this on the next tick - please check after
@@ -107,13 +108,13 @@ export class BuilderModel extends ViewModelBase {
 		const datastore: string = this.getDatastoreValues();
 		const generatedCode: string = pythonGenerator.workspaceToCode(Blockly.getMainWorkspace());
 		const code: string = `${this.state.functions}\n${generatedCode}`;
-		const psdc: any = BuilderUtilities.exportAsPyScriptApp(datastore, code);
+		const sourceCode: any = BuilderUtilities.exportAsPyScriptApp(datastore, code);
 
 		return {
 			app: JSON.stringify(BuilderUtilities.getAppAsDict(), null, 2),
 			blocks: JSON.stringify(Blockly.serialization.workspaces.save(Blockly.getMainWorkspace())),
 			datastore: JSON.stringify(this.state.datastore),
-			psdc
+			sourceCode
 		};
 	}
 
@@ -141,10 +142,10 @@ export class BuilderModel extends ViewModelBase {
 			 * host to decide where it is actually saved.
 			 */
 			case "save-request": {
-				event.source?.postMessage({
+				window.parent.postMessage({
 					type: "save-response",
 					data: this.save(),
-				});
+				}, "*");
 				break;
 			}
 
@@ -335,7 +336,7 @@ export class BuilderModel extends ViewModelBase {
 		 * add a media file. The host will send us an "add-media-response" message
 		 * if/when a media file has been added.
 		 */
-		window.parent.postMessage({type: "add-media-request"});
+		window.parent.postMessage({type: "add-media-request"}, "*");
 	}
 
 	public getImageFiles(): Array<IbSelectOption> {

--- a/src/tools/builder/src/views/builder/builder-model.ts
+++ b/src/tools/builder/src/views/builder/builder-model.ts
@@ -236,9 +236,9 @@ export class BuilderModel extends ViewModelBase {
 		this.state.activeWidgetProperties = BuilderUtilities.getComponentProperties(componentId);
 	}
 
-	public setComponentProperty(key: string, value: string, isFromDatastore?: boolean) {
+	public setComponentProperty(key: string, value: string, isLayout: boolean, isFromDatastore?: boolean,) {
 		BuilderUtilities.setComponentProperty(
-			this.state.activeWidgetId, key, value, isFromDatastore
+			this.state.activeWidgetId, key, value, isLayout, isFromDatastore
 		);
 	}
 

--- a/src/tools/builder/src/views/builder/builder.vue
+++ b/src/tools/builder/src/views/builder/builder.vue
@@ -103,7 +103,7 @@
                                     :label="key" 
                                     :options="view.getDatastoreOptions()" 
                                     v-model="property.value"
-                                    @input="view.setComponentProperty(key as string, $event, true)"
+                                    @input="view.setComponentProperty(key as string, $event, property.is_layout, true)"
                                 />
                                 <div class="w-full" v-else>
                                     <ib-select 
@@ -111,7 +111,7 @@
                                         :label="key" 
                                         :options="view.getImageFiles()" 
                                         v-model="property.value"
-                                        @input="view.setComponentProperty(key as string, $event)"
+                                        @input="view.setComponentProperty(key as string, $event, property.is_layout)"
                                     />
 
                                     <ib-select 
@@ -119,7 +119,7 @@
                                         :label="key" 
                                         :options="view.getSoundFiles()" 
                                         v-model="property.value"
-                                        @input="view.setComponentProperty(key as string, $event)"
+                                        @input="view.setComponentProperty(key as string, $event, property.is_layout)"
                                     />
 
                                     <ib-select 
@@ -127,14 +127,14 @@
                                         :label="key" 
                                         :options="view.getChoicePropertyOptions(property.choices)" 
                                         v-model="property.value"
-                                        @input="view.setComponentProperty(key as string, $event)"
+                                        @input="view.setComponentProperty(key as string, $event, property.is_layout)"
                                     />
 
                                     <ib-toggle 
                                         v-else-if="property.property_type === 'BooleanProperty'" 
                                         :label="key" 
                                         v-model="property.value"
-                                        @input="view.setComponentProperty(key as string, $event)"
+                                        @input="view.setComponentProperty(key as string, $event, property.is_layout)"
                                     />
 
                                     <ib-input 
@@ -143,7 +143,7 @@
                                         type="text"
                                         :required="property.required" 
                                         v-model="property.value"
-                                        @input="view.setComponentProperty(key as string, $event)"
+                                        @input="view.setComponentProperty(key as string, $event, property.is_layout)"
                                     />
                                 </div>
 

--- a/src/tools/wrapper/index.html
+++ b/src/tools/wrapper/index.html
@@ -3,13 +3,13 @@
     <title>Invent tooling wrapper</title>
   </head>
   <body>
-  <button id="load">Load</button>
-  <button id="save">Save</button>
-  <button id="run">Run</button>
-  <br/>
-  <iframe id="builder"
-      src="http://localhost:5173/invent"
-      style="width:100%; height:100%">
-  </iframe>
+    <button id="load">Load</button>
+    <button id="save">Save</button>
+    <br/>
+    <iframe id="builder"
+    src="http://localhost:5173/invent"
+    style="width:100%; height:100%">
+    </iframe>
+  <script src="wrapper.js"></script>
   </body>
 </html>

--- a/src/tools/wrapper/wrapper.js
+++ b/src/tools/wrapper/wrapper.js
@@ -1,0 +1,36 @@
+const builder = document.getElementById("builder");
+const save = document.getElementById("save");
+const load = document.getElementById("load");
+
+window.addEventListener("message", (event) => {
+    if (event.source === builder.contentWindow){
+        const data = event.data;
+
+        switch (data.type) {
+            case "save-response":
+                console.log(data.data);
+                localStorage.setItem("data", JSON.stringify(data.data));
+                break;
+        }
+    }
+});
+
+save.addEventListener("click", () => {
+    builder.contentWindow.postMessage({
+        type: "save-request"
+    }, "*");
+});
+
+load.addEventListener("click", () => {
+    const data = JSON.parse(localStorage.getItem("data"));
+
+    builder.contentWindow.postMessage({
+        type: "load-request",
+        data: {
+            app: data.app && JSON.parse(data.app),
+            datastore: data.datastore && JSON.parse(data.datastore),
+            blocks: data.blocks && JSON.parse(data.blocks),
+            media: {}
+        }
+    }, "*");
+});

--- a/static/main.py
+++ b/static/main.py
@@ -1,5 +1,5 @@
 import pytest
 
 
-pytest.main(["-v", "--cov=invent", "--cov-report", "term-missing", "tests/"])
+pytest.main(["-vv", "--cov=invent", "--cov-report", "term-missing", "tests/"])
 

--- a/tests/ui/core/test_component.py
+++ b/tests/ui/core/test_component.py
@@ -292,7 +292,7 @@ def test_component_as_dict():
             "name": "MyWidget 1",
             "enabled": True,
             "visible": True,
-            "layout": {"alpha": "a", "bravo": "b"},
+            "layout": dict(alpha="a", bravo="b"),
         }
     }
     assert mw.as_dict() == expected
@@ -318,7 +318,7 @@ def test_component_as_dict():
         "    name='MyWidget 1',",
         "    numberwang=55,",
         "    visible=True,",
-        "    layout={'alpha': 'a', 'bravo': 'b'},",
+        "    layout=dict(alpha='a', bravo='b'),",
         "),"
     ]
 
@@ -356,7 +356,6 @@ def test_container_as_dict():
             "border_color": None,
             "border_width": None,
             "border_style": None,
-            "layout": {},
             "content": [
                 {
                     "type": "MyWidget",
@@ -366,7 +365,7 @@ def test_container_as_dict():
                         "name": "MyWidget 1",
                         "enabled": True,
                         "visible": True,
-                        "layout": {"layout_prop": "lp"},
+                        "layout": dict(layout_prop="lp"),
                     }
                 }
             ]
@@ -384,6 +383,31 @@ def test_container_as_dict():
         mw2 = mc2.content[0]
         assert isinstance(mw2, MyWidget)
         assert isinstance(mw2.layout, MyLayout)
+
+    export._pretty_repr_component(mc, lines := [])
+    assert lines == [
+        "MyContainer(",
+        "    background_color=None,",
+        "    border_color=None,",
+        "    border_style=None,",
+        "    border_width=None,",
+        "    container_prop='cp',",
+        "    enabled=True,",
+        "    id='invent-mycontainer-1',",
+        "    name='MyContainer 1',",
+        "    visible=True,",
+        "    content=[",
+        "        MyWidget(",
+        "            enabled=True,",
+        "            id='invent-mywidget-1',",
+        "            name='MyWidget 1',",
+        "            visible=True,",
+        "            widget_prop='wp',",
+        "            layout=dict(layout_prop='lp'),",
+        "        ),",
+        "    ],",
+        "),",
+    ]
 
 
 def test_component_update_attribute():

--- a/tests/ui/core/test_property.py
+++ b/tests/ui/core/test_property.py
@@ -83,19 +83,15 @@ def test_property_from_datastore():
         mock.patch("invent.unsubscribe") as mock_unsub,
     ):
         fw.my_property = from_datastore("test", with_function=test_fn)
-        assert mock_unsub.call_count == 0
-        assert mock_sub.call_args[1]["to_channel"] == "store-data"
-        assert mock_sub.call_args[1]["when_subject"] == "test"
-        assert mock_sub.call_count == 1
+        mock_unsub.assert_not_called()
+        mock_sub.assert_called_once_with(mock.ANY, "store-data", "test")
+        reactor = mock_sub.call_args.args[0]
         test_fn.assert_called_once_with(None)
 
+        mock_sub.reset_mock()
         fw.my_property = from_datastore("test2")
-        assert mock_unsub.call_count == 1
-        assert mock_unsub.call_args[1]["to_channel"] == "store-data"
-        assert mock_unsub.call_args[1]["when_subject"] == "test"
-        assert mock_sub.call_count == 2
-        assert mock_sub.call_args[1]["to_channel"] == "store-data"
-        assert mock_sub.call_args[1]["when_subject"] == "test2"
+        mock_unsub.assert_called_once_with(reactor, "store-data", "test")
+        mock_sub.assert_called_once_with(mock.ANY, "store-data", "test2")
 
 
 def test_from_datastore_react_on_change():

--- a/tests/ui/core/test_property.py
+++ b/tests/ui/core/test_property.py
@@ -26,7 +26,7 @@ def test_from_datastore():
     fds = from_datastore("foo", with_function=test_fn)
     assert fds.key == "foo"
     assert fds.with_function == test_fn
-    assert repr(fds) == 'from_datastore("foo", with_function=test_fn)'
+    assert repr(fds) == "from_datastore('foo', with_function=test_fn)"
 
 
 def test_property_init():

--- a/utils/serve.py
+++ b/utils/serve.py
@@ -23,7 +23,7 @@ class MyHTTPRequestHandler(server.SimpleHTTPRequestHandler):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("port", type=int, default=8000)
+    parser.add_argument("port", type=int, default=8000, nargs="?")
     args = parser.parse_args()
     server.test(
         HandlerClass=MyHTTPRequestHandler, bind="localhost", port=args.port


### PR DESCRIPTION
Library:
* Layout properties are now grouped under a `layout` property. It can be initialized with a dict – see `examples` for the syntax. Once the widget has a parent, this will be replaced with a Layout object of the appropriate type.
* Code shared between Component and Layout has been factored out into a base class called Model.
* Removed unused `column_width` and `height` properties.

Builder:
* Properties are now sorted alphabetically, with layout properties at the bottom.
* The datastore is now functional within the builder.
* Renamed the save-response key `psdc` to `sourceCode` – this will have to be updated on the pyscript.com side.

Fixes:
* Fixes #98 