### PR TITLE
Apply black to codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,7 @@ clean:
 	find . | grep -E "(__pycache__)" | xargs rm -rf
 
 tidy:
-	black -l 79 src/invent
-	black -l 79 tests
-	black -l 79 utils 
-	black -l 79 examples
+	black -l 79 examples src/invent tests utils
 
 lint:
 	flake8 src/invent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-black
-flake8
+black==24.10.0
+flake8==7.1.1

--- a/src/invent/ui/containers/box.py
+++ b/src/invent/ui/containers/box.py
@@ -8,15 +8,15 @@ def justify_content_property(direction):
         f"{capitalize(direction)} alignment of children.",
         choices=ALIGNMENTS,
         default_value="start",
-        map_to_style="justify-content"
+        map_to_style="justify-content",
     )
 
 
 def flex_property(direction):
     # TODO: validate input
     return TextProperty(
-        f"How much {direction} space to consume. " +
-        "May be blank to take no extra space, "
+        f"How much {direction} space to consume. "
+        + "May be blank to take no extra space, "
         "'auto' to take an equal portion of any free space, "
         "or an integer to take the given proportion of the total space.",
         default_value="",

--- a/src/invent/ui/core/component.py
+++ b/src/invent/ui/core/component.py
@@ -190,8 +190,8 @@ class Component(Model):
     def layout(self, layout):
         def type_error():
             raise TypeError(
-                f"container type {type(self.parent).__name__} " +
-                f"doesn't support layout type {type(layout).__name__}"
+                f"container type {type(self.parent).__name__} "
+                + f"doesn't support layout type {type(layout).__name__}"
             )
 
         if isinstance(layout, Layout):
@@ -204,7 +204,7 @@ class Component(Model):
                         **{
                             key: getattr(layout, key)
                             for key, prop in layout.properties().items()
-                        }
+                        },
                     )
                 else:
                     type_error()

--- a/src/invent/ui/core/property.py
+++ b/src/invent/ui/core/property.py
@@ -438,8 +438,8 @@ class ChoiceProperty(Property):
         if value in self.choices or value is None:
             return super().validate(value)
         raise ValidationError(
-            f"The value {value!r} is not one of the valid choices " +
-            f"{self.choices}"
+            f"The value {value!r} is not one of the valid choices "
+            + f"{self.choices}"
         )
 
     def as_dict(self):

--- a/static/settings.json
+++ b/static/settings.json
@@ -3,8 +3,8 @@
         "test_suite.zip": "./*"
     },
     "packages": [
-        "pytest",
-        "pytest-cov",
-        "pytest-asyncio"
+        "pytest==8.3.3",
+        "pytest-cov==5.0.0",
+        "pytest-asyncio==0.24.0"
     ]
 }

--- a/tests/ui/core/test_component.py
+++ b/tests/ui/core/test_component.py
@@ -293,7 +293,7 @@ def test_component_as_dict():
             "enabled": True,
             "visible": True,
             "layout": dict(alpha="a", bravo="b"),
-        }
+        },
     }
     assert mw.as_dict() == expected
 
@@ -319,7 +319,7 @@ def test_component_as_dict():
         "    numberwang=55,",
         "    visible=True,",
         "    layout=dict(alpha='a', bravo='b'),",
-        "),"
+        "),",
     ]
 
 
@@ -366,10 +366,10 @@ def test_container_as_dict():
                         "enabled": True,
                         "visible": True,
                         "layout": dict(layout_prop="lp"),
-                    }
+                    },
                 }
-            ]
-        }
+            ],
+        },
     }
     assert mc.as_dict() == expected
 

--- a/tests/ui/core/test_property.py
+++ b/tests/ui/core/test_property.py
@@ -487,7 +487,10 @@ def test_choice_property_validation():
     # A valid choice is a valid value.
     widget.select = 1
     # Outside the valid choices is invalid.
-    with pytest.raises(ValidationError):
+    with pytest.raises(
+        ValidationError,
+        match=r"The value 0 is not one of the valid choices \[1, 2, 3\]",
+    ):
         widget.select = 0
 
 


### PR DESCRIPTION
`black` has been in the Makefile for a while, but some of the code doesn't comply with it. Also:

* Pinned versions of `black` and `flake8` so all developers will be consistent.
* Pinned versions of pytest packages, because `pytest-cov` released a new version 6.0.0 a few days ago, which requires a newer version of `coverage`, which doesn't have pure-Python wheels on PyPI.
* Added a test of an exception message.