### PR TITLE
Fix lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ tidy:
 	black -l 79 examples src/invent tests utils
 
 lint:
-	flake8 src/invent
+	flake8 --extend-ignore=E203,E701 src/invent
 
 lint-all:
-	flake8 src/invent tests/*
+	flake8 --extend-ignore=E203,E701 src/invent tests/*
 
 serve: clean tidy zip
 	python utils/serve.py

--- a/src/invent/ui/containers/column.py
+++ b/src/invent/ui/containers/column.py
@@ -1,6 +1,6 @@
 """
-Contains a definition of a column layout container. This is a vertical container
-box.
+Contains a definition of a column layout container. This is a vertical
+container box.
 
 Based on original pre-COVID work by [Nicholas H.Tollervey.](https://ntoll.org/)
 
@@ -19,10 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from invent.i18n import _
 from .box import Box
-from ..core.property import ChoiceProperty
-from ..core.measures import COMPONENT_DISTRIBUTION
 
 
 class Column(Box):

--- a/src/invent/ui/containers/row.py
+++ b/src/invent/ui/containers/row.py
@@ -19,10 +19,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from invent.i18n import _
 from .box import Box
-from ..core.property import ChoiceProperty
-from ..core.measures import COMPONENT_DISTRIBUTION
 
 
 class Row(Box):

--- a/src/invent/ui/core/component.py
+++ b/src/invent/ui/core/component.py
@@ -69,7 +69,8 @@ class Component:
             "Indicates how to stretch into the available space. "
             "If blank won't stretch into available space, "
             "if 'auto' will stretch an equal portion of any available space, "
-            "or an integer to stretch into the given proportion of the available space.",
+            "or an integer to stretch into the given proportion of the"
+            "available space.",
         ),
         default_value=None,
         map_to_style="flex",

--- a/src/invent/ui/core/event.py
+++ b/src/invent/ui/core/event.py
@@ -1,6 +1,6 @@
 """
-The core Event class for defining events in the life-cycle of a component in the
-Invent framework.
+The core Event class for defining events in the life-cycle of a component in
+the Invent framework.
 
 Based on original pre-COVID work by [Nicholas H.Tollervey.](https://ntoll.org/)
 

--- a/src/invent/ui/core/property.py
+++ b/src/invent/ui/core/property.py
@@ -37,9 +37,9 @@ class from_datastore:  # NOQA
     Instances of this class signal that a property is bound to a datastore
     value identified by the key.
 
-    If a with_function is provided, it is called when the value in the datastore
-    changes. The function is passed the new value from the datastore and should
-    return the value to be set on the property.
+    If a with_function is provided, it is called when the value in the
+    datastore changes. The function is passed the new value from the datastore
+    and should return the value to be set on the property.
 
     Implementation detail: snake case is used for this class, rather than the
     orthodox capitalised camel case, for aesthetic reasons. ;-)
@@ -523,7 +523,7 @@ class DateProperty(Property):
             # MicroPython doesn't support strptime, so we have to do this.
             try:
                 return datetime.date(*map(int, value.split("-")))
-            except Exception as ex:
+            except Exception:
                 raise ValidationError(_("Not a valid date."), value)
         elif value is None:
             return None
@@ -597,7 +597,7 @@ class TimeProperty(Property):
             # MicroPython doesn't support strptime, so we have to do this.
             try:
                 return datetime.time(*map(int, value.split(":")))
-            except Exception as ex:
+            except Exception:
                 raise ValidationError(_("Not a valid time."), value)
         elif value is None:
             return None

--- a/src/invent/ui/core/widget.py
+++ b/src/invent/ui/core/widget.py
@@ -45,7 +45,8 @@ class Widget(Component):
 
     channel = TextProperty(
         _(
-            "A comma separated list of channels to which the widget broadcasts."
+            "A comma separated list of channels to which the widget"
+            "broadcasts."
         ),
         default_value=None,
     )
@@ -58,7 +59,8 @@ class Widget(Component):
     def publish(self, event_name, **kwargs):
         """
         Given the name of one of the class's defined events, publish a message
-        to all the widget's channels with the message content defined in kwargs.
+        to all the widget's channels with the message content defined in
+        kwargs.
         """
         # Ensure self.channel is treated as a comma-separated list of channel
         # names.

--- a/src/invent/ui/widgets/button.py
+++ b/src/invent/ui/widgets/button.py
@@ -22,7 +22,6 @@ from invent.i18n import _
 from invent.ui.core import (
     Widget,
     TextProperty,
-    BooleanProperty,
     ChoiceProperty,
     Event,
 )

--- a/src/invent/ui/widgets/color.py
+++ b/src/invent/ui/widgets/color.py
@@ -32,7 +32,8 @@ class ColorPicker(Widget):
 
     value = TextProperty(
         _(
-            "The value of the color picker. Must be in seven-character hexadecimal notation."
+            "The value of the color picker. Must be in seven-character"
+            "hexadecimal notation."
         ),
         default_value="#000000",
         min_length=7,

--- a/src/invent/ui/widgets/date.py
+++ b/src/invent/ui/widgets/date.py
@@ -22,7 +22,7 @@ from invent.i18n import _
 from pyscript.web import input_, label, div
 from pyscript.ffi import create_proxy
 
-from invent.ui.core import Widget, DateProperty, TextProperty, TimeProperty
+from invent.ui.core import Widget, DateProperty, TextProperty
 
 
 class DatePicker(Widget):

--- a/src/invent/ui/widgets/fileupload.py
+++ b/src/invent/ui/widgets/fileupload.py
@@ -22,7 +22,7 @@ from invent.i18n import _
 from pyscript.web import input_
 from pyscript.ffi import create_proxy
 
-from invent.ui.core import Widget, BooleanProperty, ListProperty
+from invent.ui.core import Widget, ListProperty
 
 
 class FileUpload(Widget):

--- a/src/invent/ui/widgets/label.py
+++ b/src/invent/ui/widgets/label.py
@@ -1,5 +1,5 @@
 """
-A label widget to contain textual content that understands Markdown, for the 
+A label widget to contain textual content that understands Markdown, for the
 Invent framework.
 
 Based on original pre-COVID work by [Nicholas H.Tollervey.](https://ntoll.org/)

--- a/src/invent/ui/widgets/radio.py
+++ b/src/invent/ui/widgets/radio.py
@@ -80,12 +80,6 @@ class Radio(Widget):
     def on_value_changed(self):
         self._radio_element.value = self.value
 
-    def on_name_changed(self):
-        """
-        Ensure the name is always the group.
-        """
-        self._radio_element.name = self.group
-
     def render(self):
         self._radio_element = input_(type="radio", id=self.id, name=self.group)
         self._text_span = span(self.label)

--- a/src/invent/ui/widgets/selector.py
+++ b/src/invent/ui/widgets/selector.py
@@ -19,7 +19,7 @@ limitations under the License.
 """
 
 from invent.i18n import _
-from pyscript.web import select, option
+from pyscript.web import select
 from pyscript.ffi import create_proxy
 
 from invent.ui.core import (

--- a/src/invent/ui/widgets/time.py
+++ b/src/invent/ui/widgets/time.py
@@ -22,7 +22,7 @@ from invent.i18n import _
 from pyscript.web import input_, label, div
 from pyscript.ffi import create_proxy
 
-from invent.ui.core import Widget, DateProperty, TextProperty, TimeProperty
+from invent.ui.core import Widget, TextProperty, TimeProperty
 
 
 class TimePicker(Widget):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 from pyscript.web import page
-from pyscript import storage
 
 import invent
 import invent.app

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -43,7 +43,7 @@ def test_initialise_app_with_media_root():
     """
     Test that the App class can be initialised with a media root.
     """
-    app = invent.app.App(name="Test App", media_root="media")
+    _ = invent.app.App(name="Test App", media_root="media")
     root = invent.get_media_root()
     assert root == "media", f"{root} is not 'media'"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,7 +75,8 @@ def test_iscoroutinefunction():
 
 def test_iscoroutinefunction_with_closure():
     """
-    Test that iscoroutinefunction returns True for a coroutine function as a closure.
+    Test that iscoroutinefunction returns True for a coroutine function
+    as a closure.
     """
     x = 1
 

--- a/tests/ui/core/test_property.py
+++ b/tests/ui/core/test_property.py
@@ -100,7 +100,9 @@ def test_property_from_datastore():
     test_fn = umock.Mock()
     fw = FakeWidget()
     # fmt: off
-    with umock.patch("invent:subscribe") as mock_sub, umock.patch("invent:unsubscribe") as mock_unsub:
+    with umock.patch(
+            "invent:subscribe"
+    ) as mock_sub, umock.patch("invent:unsubscribe") as mock_unsub:
         fw.my_property = from_datastore("test", with_function=test_fn)
         mock_unsub.assert_not_called()
         mock_sub.assert_called_once()


### PR DESCRIPTION
Hi @ntoll!

I created a new environment and ran `make lint-all`, and I got some lint errors. This PR corrects them and also tweaks the flake8 configuration based on the [black docs](https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#minimal-configuration) while trying to respect your line-length preference.

```
(.venv) ~/P/invent (main|✔) $ make lint-all                                                                                                                                                                                 (base) 
flake8 src/invent tests/*
src/invent/ui/containers/column.py:2:80: E501 line too long (80 > 79 characters)
src/invent/ui/containers/column.py:22:1: F401 'invent.i18n._' imported but unused
src/invent/ui/containers/column.py:24:1: F401 '..core.property.ChoiceProperty' imported but unused
src/invent/ui/containers/column.py:25:1: F401 '..core.measures.COMPONENT_DISTRIBUTION' imported but unused
src/invent/ui/containers/row.py:22:1: F401 'invent.i18n._' imported but unused
src/invent/ui/containers/row.py:24:1: F401 '..core.property.ChoiceProperty' imported but unused
src/invent/ui/containers/row.py:25:1: F401 '..core.measures.COMPONENT_DISTRIBUTION' imported but unused
src/invent/ui/core/component.py:72:80: E501 line too long (89 > 79 characters)
src/invent/ui/core/event.py:2:80: E501 line too long (80 > 79 characters)
src/invent/ui/core/property.py:40:80: E501 line too long (80 > 79 characters)
src/invent/ui/core/property.py:526:13: F841 local variable 'ex' is assigned to but never used
src/invent/ui/core/property.py:600:13: F841 local variable 'ex' is assigned to but never used
src/invent/ui/core/widget.py:48:80: E501 line too long (80 > 79 characters)
src/invent/ui/core/widget.py:61:80: E501 line too long (80 > 79 characters)
src/invent/ui/widgets/button.py:22:1: F401 'invent.ui.core.BooleanProperty' imported but unused
src/invent/ui/widgets/code.py:23:1: F401 'pyscript.web.link' imported but unused
src/invent/ui/widgets/code.py:23:1: F401 'pyscript.web.page' imported but unused
src/invent/ui/widgets/color.py:35:80: E501 line too long (93 > 79 characters)
src/invent/ui/widgets/date.py:25:1: F401 'invent.ui.core.TimeProperty' imported but unused
src/invent/ui/widgets/fileupload.py:25:1: F401 'invent.ui.core.BooleanProperty' imported but unused
src/invent/ui/widgets/label.py:2:77: W291 trailing whitespace
src/invent/ui/widgets/radio.py:83:5: F811 redefinition of unused 'on_name_changed' from line 65
src/invent/ui/widgets/selector.py:22:1: F401 'pyscript.web.option' imported but unused
src/invent/ui/widgets/table.py:90:5: E303 too many blank lines (2)
src/invent/ui/widgets/table.py:92:1: W293 blank line contains whitespace
src/invent/ui/widgets/table.py:95:1: W293 blank line contains whitespace
src/invent/ui/widgets/time.py:25:1: F401 'invent.ui.core.DateProperty' imported but unused
tests/conftest.py:2:1: F401 'pyscript.storage' imported but unused
tests/test_app.py:46:5: F841 local variable 'app' is assigned to but never used
tests/test_utils.py:78:80: E501 line too long (85 > 79 characters)
tests/ui/core/test_property.py:103:80: E501 line too long (102 > 79 characters)
make: *** [lint-all] Error 1
```
