### PR TITLE
Property rename cleanups

### DIFF
--- a/examples/farmyard/main.py
+++ b/examples/farmyard/main.py
@@ -95,7 +95,7 @@ app = invent.App(
                                     value=from_datastore("number_of_honks"),
                                     name="Honk Slider",
                                     step=1,
-                                    stretch=2,
+                                    flex=1,
                                 ),
                             ]
                         ),

--- a/examples/theme_testcard/main.py
+++ b/examples/theme_testcard/main.py
@@ -484,7 +484,12 @@ print(Hello().greet)"""
                                     border_width="S",
                                     border_style="Dotted",
                                     flex=2,
-                                    children=[Label(text="Flexed to fill.")],
+                                    vertical_align_content="center",
+                                    children=[
+                                        Label(
+                                            text="Flexed to fill, v align content center"
+                                        )
+                                    ],
                                 ),
                             ],
                         ),
@@ -525,8 +530,21 @@ print(Hello().greet)"""
                                 Label(
                                     text="Item 8", background_color="lightgrey"
                                 ),
-                                Label(
-                                    text="Item 9", background_color="lightgrey"
+                                Row(
+                                    border_color="red",
+                                    border_width="S",
+                                    border_style="Dotted",
+                                    horizontal_align_content="center",
+                                    children=[
+                                        Label(
+                                            text="Item 9a, h align content center",
+                                            background_color="lightgrey",
+                                        ),
+                                        Label(
+                                            text="Item 9b",
+                                            background_color="lightgrey",
+                                        ),
+                                    ],
                                 ),
                             ],
                         ),

--- a/src/invent/ui/containers/box.py
+++ b/src/invent/ui/containers/box.py
@@ -22,7 +22,7 @@ limitations under the License.
 from invent.i18n import _
 from ..core.container import Container
 from ..core.property import ChoiceProperty
-from ..core.measures import TSHIRT_SIZES, MEDIUM, COMPONENT_DISTRIBUTION
+from ..core.measures import TSHIRT_SIZES, MEDIUM
 
 
 class Box(Container):

--- a/src/invent/ui/containers/column.py
+++ b/src/invent/ui/containers/column.py
@@ -30,7 +30,7 @@ class Column(Box):
     A vertical container box.
     """
 
-    content_vertical_align = ChoiceProperty(
+    vertical_align_content = ChoiceProperty(
         _("Alignment of child components in this column."),
         choices=COMPONENT_DISTRIBUTION,
         map_to_style="justify-content",

--- a/src/invent/ui/containers/grid.py
+++ b/src/invent/ui/containers/grid.py
@@ -57,10 +57,6 @@ class Grid(Container):
     def on_columns_changed(self):
         self.element.style["grid-template-columns"] = "auto " * self.columns
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.content_align = "stretch"
-
     def render(self):
         """
         Render the component.

--- a/src/invent/ui/containers/row.py
+++ b/src/invent/ui/containers/row.py
@@ -30,7 +30,7 @@ class Row(Box):
     A horizontal container box.
     """
 
-    content_horizontal_align = ChoiceProperty(
+    horizontal_align_content = ChoiceProperty(
         _("Alignment of child components in this row."),
         choices=COMPONENT_DISTRIBUTION,
         map_to_style="justify-content",


### PR DESCRIPTION
* Changed `content_vertical_align` to `vertical_align_content`, and similarly with `horizontal`. This is consistent with the verb-object ordering which is followed by this area of CSS, and will also make it more readable if we add the `items` properties in the future. See [this Toga issue](https://github.com/beeware/toga/issues/3111) for discussion.

* Added both properties to the testcard.

* Miscellaneous cleanups from the previous renaming.