### PR TITLE
Remove references to ZIP files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,8 +114,6 @@ venv.bak/
 # vim
 *.swp
 
-# Zipped up assets
-invent.zip
-test_suite.zip
+# Packaged assets
 invent.tar.gz
 test_suite.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,14 @@ all:
 	@echo "make dist - build the module as a package."
 	@echo "make publish-test - upload the package to the PyPI test instance."
 	@echo "make publish-live - upload the package to the PyPI LIVE instance."
-	@exho "make zip - create a zip archive of the framework and test suite."
+	@echo "make package - create an archive of the framework and test suite."
 
 clean:
 	rm -rf .pytest_cache
 	rm -rf dist
-	rm -rf invent.zip
-	rm -rf test_suite.zip
-	rm -rf src/tools/builder/src/python/invent.zip
-	rm -rf static/*.zip
 	rm -rf invent.tar.gz
 	rm -rf test_suite.tar.gz
 	rm -rf src/tools/builder/src/python/invent.tar.gz
-	rm -rf static/*.zip
 	rm -rf static/*.tar.gz
 	rm -rf test_suite
 	find . | grep -E "(__pycache__)" | xargs rm -rf
@@ -39,7 +34,7 @@ lint:
 lint-all:
 	flake8 --extend-ignore=E203,E701 src/invent tests/*
 
-serve: clean tidy zip
+serve: clean tidy package
 	python utils/serve.py
 
 test:
@@ -60,13 +55,11 @@ publish-live: dist
 	python3 -m pip install --upgrade twine
 	python3 -m twine upload --sign dist/*
 
-zip:
+package:
 	cd src && tar --no-xattrs -czvf ../invent.tar.gz invent/*
-	#cd src && zip -qr ../invent.zip invent/*
 	mkdir test_suite
 	cp -r src/invent test_suite
 	cp -r tests test_suite
-	# cd test_suite && zip -qr ../test_suite.zip tests/* invent/*
 	cd test_suite && tar --no-xattrs -czvf ../test_suite.tar.gz tests/* invent/*
 	rm -rf test_suite
 	cp invent.tar.gz static/
@@ -74,5 +67,3 @@ zip:
 	cp test_suite.tar.gz static/
 	rm invent.tar.gz
 	rm test_suite.tar.gz
-
-zip-all: lint-all clean tidy zip

--- a/README.md
+++ b/README.md
@@ -55,22 +55,8 @@ Make a virtualenv, then install the requirements:
 pip install -r requirements.txt
 ```
 
-Most useful developer related tasks are automated by a `Makefile`:
-
-```
-$ make
-There's no default Makefile target right now. Try:
-
-make clean - reset the project and remove auto-generated assets.
-make tidy - tidy up the code with the 'black' formatter.
-make lint - check the code for obvious errors with flake8.
-make lint-all - check all code for obvious errors with flake8.
-make serve - serve the project at: http://0.0.0.0:8000/
-make test - while serving the app, run the test suite in browser.
-make dist - build the module as a package.
-make publish-test - upload the package to the PyPI test instance.
-make publish-live - upload the package to the PyPI LIVE instance.
-```
+Most useful developer related tasks are automated by a `Makefile`. Type `make`
+for a list of the available commands.
 
 To run the test suite:
 

--- a/utils/serve.py
+++ b/utils/serve.py
@@ -65,12 +65,12 @@ class SourceChangeHander(FileSystemEventHandler):
 
     def restart_server(self):
         """
-        Stop the server subprocess, `make zip`, and restart the server
+        Stop the server subprocess, `make package`, and restart the server
         subprocess.
         """
         print("♻️  Restarting server...")
         self.stop_server()
-        subprocess.run(["make", "zip"])
+        subprocess.run(["make", "package"])
         self.start_server()
 
     def start_server(self):


### PR DESCRIPTION
Everything switched over to using the .tar.gz files some time ago, but there were still a few references to the .zips.